### PR TITLE
Remove createJSModules @Override

### DIFF
--- a/android/app/src/main/java/com/lynxit/contactswrapper/ContactsWrapperPackage.java
+++ b/android/app/src/main/java/com/lynxit/contactswrapper/ContactsWrapperPackage.java
@@ -15,7 +15,7 @@ import java.util.List;
  */
 public class ContactsWrapperPackage implements ReactPackage {
 
-    @Override
+    // Deprecated in React Native 0.47
     public List<Class<? extends JavaScriptModule>> createJSModules() {
         return Collections.emptyList();
     }


### PR DESCRIPTION
createJSModule was removed in React Native 0.47. By removing the override annotation this now compiles correctly again in all versions of React Native.