### PR TITLE
Fix not opening on iOS with nested modal views

### DIFF
--- a/ios/RCTContactsWrapper/RCTContactsWrapper.m
+++ b/ios/RCTContactsWrapper/RCTContactsWrapper.m
@@ -67,14 +67,10 @@ RCT_EXPORT_METHOD(getEmail:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseR
   }
   //Launch Contact Picker or Address Book View Controller
   UIViewController *root = [[[UIApplication sharedApplication] delegate] window].rootViewController;
-  BOOL modalPresent = (BOOL) (root.presentedViewController);
-  if (modalPresent) {
-	  UIViewController *parent = root.presentedViewController;
-	  [parent presentViewController:picker animated:YES completion:nil];
-  } else {
-	  [root presentViewController:picker animated:YES completion:nil];
+  while (root.presentedViewController) {
+    root = root.presentedViewController;
   }
-  
+  [root presentViewController:picker animated:YES completion:nil];
 }
 
 


### PR DESCRIPTION
The earlier fix in c3cda7fa3c07ef316f05c2aba6b5ce0f5ce532ae did not
handle nested modal views. It only considered the first "level" along
the stack.