### PR TITLE
Use safeExtGet to use root project build settings

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -1,12 +1,16 @@
+def safeExtGet(prop, fallback) {
+    rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
 apply plugin: "com.android.library"
 
 android {
-    compileSdkVersion 27
-    buildToolsVersion "27.0.1"
+    compileSdkVersion safeExtGet("compileSdkVersion", 27)
+    buildToolsVersion safeExtGet("buildToolsVersion", "27.0.1")
 
     defaultConfig {
-        minSdkVersion 16
-        targetSdkVersion 22
+        minSdkVersion safeExtGet("minSdkVersion", 16)
+        targetSdkVersion safeExtGet("targetSdkVersion", 22)
         versionCode 1
         versionName "1.0"
         ndk {


### PR DESCRIPTION
Common strategy implemented in: oney/react-native-webrtc#494